### PR TITLE
Remove RefCell and UnsafeCell use

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,6 +410,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "futures 0.3.17",
+ "spin",
  "tokio",
  "tokio-test",
  "tracing",
@@ -636,6 +637,15 @@ name = "smallvec"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+
+[[package]]
+name = "spin"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "syn"

--- a/packline_core/Cargo.toml
+++ b/packline_core/Cargo.toml
@@ -16,6 +16,7 @@ tokio = { version = "1.11.0", features = ["process", "net", "macros"] }
 async-trait = { version = "0.1.48" }
 futures = "0.3.13"
 tracing = "0.1"
+spin = "0.9.2"
 
 [features]
 default = []

--- a/packline_core/src/app/channel/channel.rs
+++ b/packline_core/src/app/channel/channel.rs
@@ -1,4 +1,3 @@
-use std::cell::{RefCell, UnsafeCell};
 use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -8,7 +7,6 @@ use tokio::sync::RwLock;
 
 use crate::app::channel::consumer::{BaseConsumerStrategy, Consumer, ConsumerWaker};
 use crate::app::channel::storage::VecStorage;
-use crate::app::channel::UnsafeSync;
 
 use super::consumer::ConsumerStrategy;
 use super::storage::ChannelStorage;
@@ -16,12 +14,12 @@ use crate::app::channel::producer::Producer;
 
 #[derive(Clone)]
 pub struct Channel {
-    inner: Arc<UnsafeSync<UnsafeCell<Inner>>>,
+    inner: Arc<Inner>,
 }
 
 pub(crate) struct Inner {
-    pub storage: Option<Rc<RefCell<dyn ChannelStorage>>>,
-    pub consumer_strategy: Option<Rc<RefCell<dyn ConsumerStrategy>>>,
+    pub storage: Option<Rc<dyn ChannelStorage>>,
+    pub consumer_strategy: Option<Rc<dyn ConsumerStrategy>>,
 
     pub consumer_group_handlers: RwLock<HashMap<u128, Arc<ConsumerGroupHandler>>>,
 }
@@ -29,26 +27,18 @@ pub(crate) struct Inner {
 unsafe impl Send for Inner {}
 unsafe impl Sync for Inner {}
 
-unsafe impl<T> Send for UnsafeSync<T> {}
-unsafe impl<T> Sync for UnsafeSync<T> {}
-
 impl Channel {
     pub fn new(app: crate::app::App) -> Self {
         let inner = Inner::new(app);
 
-        Channel {
-            inner: Arc::new(UnsafeSync::new(UnsafeCell::new(inner))),
-        }
+        Channel { inner: Arc::new(inner) }
     }
 
     pub fn consumer(&self, consumer_id: u128) -> Consumer {
-        unsafe {
-            let pointer: &mut Inner = &mut *self.inner.get();
-            Consumer::new(
-                consumer_id,
-                futures::executor::block_on(pointer.consumer_group_handler(consumer_id)),
-            )
-        }
+        Consumer::new(
+            consumer_id,
+            futures::executor::block_on(self.inner.consumer_group_handler(consumer_id)),
+        )
     }
 
     pub fn producer(&self) -> Producer {
@@ -64,17 +54,17 @@ impl Inner {
             consumer_group_handlers: RwLock::new(HashMap::new()),
         };
 
-        let storage = Rc::new(RefCell::new(VecStorage::new(app.clone(), &mut inner)));
+        let storage = Rc::new(VecStorage::new(app.clone(), &mut inner));
         inner.storage = Some(storage);
 
-        let consumer_strategy = Rc::new(RefCell::new(BaseConsumerStrategy::new(app, &mut inner)));
+        let consumer_strategy = Rc::new(BaseConsumerStrategy::new(app, &mut inner));
         inner.consumer_strategy = Some(consumer_strategy);
 
         inner
     }
 
-    pub fn produce(&mut self, data: &mut Vec<u32>) {
-        self.consumer_strategy.as_ref().unwrap().borrow_mut().produce(data);
+    pub fn produce(&self, data: &mut Vec<u32>) {
+        self.consumer_strategy.as_ref().unwrap().produce(data);
 
         let guard = futures::executor::block_on(self.consumer_group_handlers.read());
         for (_, consumer_group_handler) in guard.iter() {
@@ -83,8 +73,8 @@ impl Inner {
     }
 
     #[allow(dead_code)]
-    pub async fn consume(&mut self, offset: usize, count: usize) -> Option<Vec<u32>> {
-        let result = self.consumer_strategy.as_ref().unwrap().borrow().consume(offset, count);
+    pub async fn consume(&self, offset: usize, count: usize) -> Option<Vec<u32>> {
+        let result = self.consumer_strategy.as_ref().unwrap().consume(offset, count);
 
         result
     }
@@ -113,7 +103,7 @@ impl Inner {
 
 pub(crate) struct ConsumerGroupHandler {
     offset: AtomicUsize,
-    consumer_strategy: Rc<RefCell<dyn ConsumerStrategy>>,
+    consumer_strategy: Rc<dyn ConsumerStrategy>,
 
     waker: Arc<ConsumerWaker>,
 }
@@ -129,7 +119,7 @@ impl ConsumerGroupHandler {
     pub async fn consume(&self, count: usize) -> Option<Vec<u32>> {
         let current_offset = self.offset.load(Ordering::Relaxed);
 
-        let result = self.consumer_strategy.borrow().consume(current_offset, count);
+        let result = self.consumer_strategy.consume(current_offset, count);
         if let Some(data) = &result {
             self.offset.store(current_offset + data.len(), Ordering::Relaxed);
         }

--- a/packline_core/src/app/channel/consumer.rs
+++ b/packline_core/src/app/channel/consumer.rs
@@ -1,4 +1,3 @@
-use std::cell::RefCell;
 use std::collections::LinkedList;
 use std::future::Future;
 use std::pin::Pin;
@@ -22,12 +21,12 @@ pub(crate) trait ConsumerStrategy: Send + Sync {
     where
         Self: Sized;
 
-    fn produce(&mut self, data: &mut Vec<u32>);
+    fn produce(&self, data: &mut Vec<u32>);
     fn consume(&self, offset: usize, count: usize) -> Option<Vec<u32>>;
 }
 
 pub struct BaseConsumerStrategy {
-    storage: Rc<RefCell<dyn ChannelStorage>>,
+    storage: Rc<dyn ChannelStorage>,
 }
 
 unsafe impl Send for BaseConsumerStrategy {}
@@ -41,12 +40,12 @@ impl ConsumerStrategy for BaseConsumerStrategy {
         }
     }
 
-    fn produce(&mut self, data: &mut Vec<u32>) {
-        self.storage.borrow_mut().enqueue(data);
+    fn produce(&self, data: &mut Vec<u32>) {
+        self.storage.enqueue(data);
     }
 
     fn consume(&self, offset: usize, count: usize) -> Option<Vec<u32>> {
-        let result = self.storage.borrow().peek(offset, count);
+        let result = self.storage.peek(offset, count);
 
         if result.is_empty() {
             None

--- a/packline_core/src/app/channel/consumer.rs
+++ b/packline_core/src/app/channel/consumer.rs
@@ -2,7 +2,6 @@ use spin::Mutex;
 use std::collections::LinkedList;
 use std::future::Future;
 use std::pin::Pin;
-use std::rc::Rc;
 use std::sync::{Arc, Weak};
 use std::task::{Context, Poll, Waker};
 
@@ -26,12 +25,8 @@ pub(crate) trait ConsumerStrategy: Send + Sync {
 }
 
 pub struct BaseConsumerStrategy {
-    storage: Rc<dyn ChannelStorage>,
+    storage: Arc<dyn ChannelStorage>,
 }
-
-unsafe impl Send for BaseConsumerStrategy {}
-
-unsafe impl Sync for BaseConsumerStrategy {}
 
 impl ConsumerStrategy for BaseConsumerStrategy {
     fn new(_: crate::app::App, channel: &mut Inner) -> Self {
@@ -133,8 +128,6 @@ pub struct Consumer {
     handler: Arc<ConsumerGroupHandler>,
 }
 
-unsafe impl Send for Consumer {}
-
 struct ConsumerConfigs {
     timeout: u64,
 }
@@ -169,7 +162,6 @@ pub struct ConsumerFuture {
 }
 
 unsafe impl Send for ConsumerFuture {}
-
 unsafe impl Sync for ConsumerFuture {}
 
 impl<'a> ConsumerFuture {

--- a/packline_core/src/app/channel/mod.rs
+++ b/packline_core/src/app/channel/mod.rs
@@ -1,5 +1,3 @@
-use std::ops::{Deref, DerefMut};
-
 pub use channel::Channel;
 pub(crate) use channel::Inner;
 
@@ -8,30 +6,6 @@ mod channel;
 pub mod consumer;
 pub mod producer;
 pub mod storage;
-
-pub struct UnsafeSync<T> {
-    inner: T,
-}
-
-impl<T> UnsafeSync<T> {
-    fn new(value: T) -> Self {
-        UnsafeSync { inner: value }
-    }
-}
-
-impl<T> Deref for UnsafeSync<T> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        &self.inner
-    }
-}
-
-impl<T> DerefMut for UnsafeSync<T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.inner
-    }
-}
 
 #[cfg(test)]
 mod tests {

--- a/packline_core/src/app/channel/producer.rs
+++ b/packline_core/src/app/channel/producer.rs
@@ -1,23 +1,19 @@
-use std::cell::UnsafeCell;
 use std::sync::Arc;
 
-use crate::app::channel::{Inner, UnsafeSync};
+use crate::app::channel::Inner;
 
 pub struct Producer {
-    inner: Arc<UnsafeSync<UnsafeCell<Inner>>>,
+    inner: Arc<Inner>,
 }
 
 unsafe impl Send for Producer {}
 
 impl<'a> Producer {
-    pub(crate) fn new(inner: Arc<UnsafeSync<UnsafeCell<Inner>>>) -> Self {
+    pub(crate) fn new(inner: Arc<Inner>) -> Self {
         Producer { inner }
     }
 
     pub async fn produce(&mut self, data: &mut Vec<u32>) {
-        unsafe {
-            let pointer: &mut Inner = &mut *self.inner.get();
-            pointer.produce(data);
-        }
+        self.inner.produce(data);
     }
 }

--- a/packline_core/src/app/channel/producer.rs
+++ b/packline_core/src/app/channel/producer.rs
@@ -6,8 +6,6 @@ pub struct Producer {
     inner: Arc<Inner>,
 }
 
-unsafe impl Send for Producer {}
-
 impl<'a> Producer {
     pub(crate) fn new(inner: Arc<Inner>) -> Self {
         Producer { inner }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Make `ConsumerStrategy` and `ChannelStorage` traits safe for shared mutability, forwarding the responsibility of thread safety to trait implementation, so RefCell and UnsafeCell can be removed, removing unsafe code.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Resolves #16 

## Motivation and Context
Remove unsafe code.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

